### PR TITLE
fix: add FloatColumnType and UuidColumnType to ColumnTypeConverter.Read

### DIFF
--- a/src/Pure.RelationalSchema.Abstractions.Serialization.System/ColumnTypeConverter.cs
+++ b/src/Pure.RelationalSchema.Abstractions.Serialization.System/ColumnTypeConverter.cs
@@ -28,6 +28,8 @@ public sealed class ColumnTypeConverter : JsonConverter<IColumnType>
             new ULongColumnType(),
             new UShortColumnType(),
             new DoubleColumnType(),
+            new FloatColumnType(),
+            new UuidColumnType(),
         ];
 
         return types.FirstOrDefault(x => x.Name.TextValue == columnType)


### PR DESCRIPTION
Fixes #46.

`FloatColumnType` and `UuidColumnType` were missing from the deserialization list in `ColumnTypeConverter.Read`, causing `JsonException` on round-trip for schemas with float or uuid columns.